### PR TITLE
added objectAssign method

### DIFF
--- a/objectAssign.js
+++ b/objectAssign.js
@@ -1,0 +1,15 @@
+'use strict';
+
+//Allows for objects to be combined together. This method is no longer needed because you can use the object spread syntax instead. Like the object spread operator, Object.assign() does not do deep cloning. Lodash is your best friend when it comes to deep cloning objects.
+//Example:  Combine two objects into one.
+
+const firstObject = {
+  firstName: 'Hector'
+}
+const secondObject = {
+  lastName: 'Norza'
+}
+const combinedObject = Object.assign(firstObject, secondObject);
+console.log(combinedObject);
+
+//Result should be: {firstName: "Hector", lastName: "Norza"}


### PR DESCRIPTION
This method allows for objects to be combined together. This method is no longer needed because you can use the object spread syntax instead. Like the object spread operator, Object.assign() does not do deep cloning. Lodash is your best friend when it comes to deep cloning objects.
